### PR TITLE
Added Verbose option to DonutConfig

### DIFF
--- a/donut/donut.go
+++ b/donut/donut.go
@@ -71,7 +71,9 @@ func ShellcodeFromBytes(buf *bytes.Buffer, config *DonutConfig) (*bytes.Buffer, 
 	}
 	// If the module will be stored on a remote server
 	if config.InstType == DONUT_INSTANCE_URL {
-		log.Printf("Saving %s to disk.\n", config.ModuleName)
+		if config.Verbose {
+			log.Printf("Saving %s to disk.\n", config.ModuleName)
+		}
 		// save the module to disk using random name
 		instance.Write([]byte{0, 0, 0, 0, 0, 0, 0, 0})          // mystery padding
 		config.ModuleData.Write([]byte{0, 0, 0, 0, 0, 0, 0, 0}) // mystery padding
@@ -157,19 +159,27 @@ func CreateModule(config *DonutConfig, inputFile *bytes.Buffer) error {
 		copy(mod.Domain[:], []byte(config.Domain)[:])
 
 		if config.Type == DONUT_MODULE_NET_DLL {
-			log.Println("Class:", config.Class)
+			if config.Verbose {
+				log.Println("Class:", config.Class)
+			}
 			copy(mod.Cls[:], []byte(config.Class)[:])
-			log.Println("Method:", config.Method)
+			if config.Verbose {
+				log.Println("Method:", config.Method)
+			}
 			copy(mod.Method[:], []byte(config.Method)[:])
 		}
 		// If no runtime specified in configuration, use default
 		if config.Runtime == "" {
 			config.Runtime = "v2.0.50727"
 		}
-		log.Println("Runtime:", config.Runtime)
+		if config.Verbose {
+			log.Println("Runtime:", config.Runtime)
+		}
 		copy(mod.Runtime[:], []byte(config.Runtime)[:])
 	} else if config.Type == DONUT_MODULE_DLL && config.Method != "" { // Unmanaged DLL? check for exported api
-		log.Println("DLL function:", config.Method)
+		if config.Verbose {
+			log.Println("DLL function:", config.Method)
+		}
 		copy(mod.Method[:], []byte(config.Method))
 	}
 	mod.Zlen = 0 // todo: support compression
@@ -217,12 +227,16 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 	// if this is a PIC instance, add the size of module
 	// that will be appended to the end of structure
 	if config.InstType == DONUT_INSTANCE_PIC {
-		log.Printf("The size of module is %v bytes. Adding to size of instance.\n", modLen)
+		if config.Verbose {
+			log.Printf("The size of module is %v bytes. Adding to size of instance.\n", modLen)
+		}
 		instLen += modLen
 	}
 
 	if config.Entropy == DONUT_ENTROPY_DEFAULT {
-		log.Println("Generating random key for instance")
+		if config.Verbose {
+			log.Println("Generating random key for instance")
+		}
 		tk, err := GenerateRandomBytes(16)
 		if err != nil {
 			return nil, err
@@ -235,7 +249,9 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 		}
 		copy(inst.KeyCtr[:], tk)
 
-		log.Println("Generating random key for module")
+		if config.Verbose {
+			log.Println("Generating random key for module")
+		}
 		tk, err = GenerateRandomBytes(16)
 		if err != nil {
 			return nil, err
@@ -248,11 +264,15 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 		}
 		copy(inst.ModKeyCtr[:], tk)
 
-		log.Println("Generating random string to verify decryption")
+		if config.Verbose {
+			log.Println("Generating random string to verify decryption")
+		}
 		sbsig := RandomString(DONUT_SIG_LEN)
 		copy(inst.Sig[:], []byte(sbsig))
 
-		log.Println("Generating random IV for Maru hash")
+		if config.Verbose {
+			log.Println("Generating random IV for Maru hash")
+		}
 		iv, err := GenerateRandomBytes(MARU_IV_LEN)
 		if err != nil {
 			return nil, err
@@ -261,7 +281,9 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 
 		inst.Mac = Maru(inst.Sig[:], inst.Iv)
 	}
-	log.Println("Generating hashes for API using IV:", inst.Iv)
+	if config.Verbose {
+		log.Println("Generating hashes for API using IV:", inst.Iv)
+	}
 
 	for cnt, c := range api_imports {
 		// calculate hash for DLL string
@@ -271,10 +293,12 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 		// xor with DLL hash and store in instance
 		inst.Hash[cnt] = Maru([]byte(c.Name), inst.Iv) ^ dllHash
 
-		log.Printf("Hash for %s : %s = %x\n",
-			c.Module,
-			c.Name,
-			inst.Hash[cnt])
+		if config.Verbose {
+			log.Printf("Hash for %s : %s = %x\n",
+				c.Module,
+				c.Name,
+				inst.Hash[cnt])
+		}
 	}
 	// save how many API to resolve
 	inst.ApiCount = uint32(len(api_imports))
@@ -283,7 +307,9 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 	// if module is .NET assembly
 	if config.Type == DONUT_MODULE_NET_DLL ||
 		config.Type == DONUT_MODULE_NET_EXE {
-		log.Println("Copying GUID structures and DLL strings for loading .NET assemblies")
+		if config.Verbose {
+			log.Println("Copying GUID structures and DLL strings for loading .NET assemblies")
+		}
 		copy(inst.XIID_AppDomain[:], xIID_AppDomain[:])
 		copy(inst.XIID_ICLRMetaHost[:], xIID_ICLRMetaHost[:])
 		copy(inst.XCLSID_CLRMetaHost[:], xCLSID_CLRMetaHost[:])
@@ -292,7 +318,9 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 		copy(inst.XCLSID_CorRuntimeHost[:], xCLSID_CorRuntimeHost[:])
 	} else if config.Type == DONUT_MODULE_VBS ||
 		config.Type == DONUT_MODULE_JS {
-		log.Println("Copying GUID structures and DLL strings for loading VBS/JS")
+		if config.Verbose {
+			log.Println("Copying GUID structures and DLL strings for loading VBS/JS")
+		}
 
 		copy(inst.XIID_IUnknown[:], xIID_IUnknown[:])
 		copy(inst.XIID_IDispatch[:], xIID_IDispatch[:])
@@ -354,17 +382,23 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 				// generate a random name for module
 				// that will be saved to disk
 				config.ModuleName = RandomString(DONUT_MAX_MODNAME)
-				log.Println("Generated random name for module :", config.ModuleName)
+				if config.Verbose {
+					log.Println("Generated random name for module :", config.ModuleName)
+				}
 			} else {
 				config.ModuleName = "AAAAAAAA"
 			}
 		}
-		log.Println("Setting URL parameters")
+		if config.Verbose {
+			log.Println("Setting URL parameters")
+		}
 		// append module name
 		copy(inst.Url[:], config.URL+"/"+config.ModuleName)
 		// set the request verb
 		copy(inst.Req[:], "GET")
-		log.Println("Payload will attempt download from:", string(inst.Url[:]))
+		if config.Verbose {
+			log.Println("Payload will attempt download from:", string(inst.Url[:]))
+		}
 	}
 
 	inst.Mod_len = uint64(modLen) + 8 //todo: this 8 is from alignment I think?
@@ -373,7 +407,9 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 	config.instLen = instLen
 
 	if config.InstType == DONUT_INSTANCE_URL && config.Entropy == DONUT_ENTROPY_DEFAULT {
-		log.Println("encrypting module for download")
+		if config.Verbose {
+			log.Println("encrypting module for download")
+		}
 		config.ModuleMac = Maru(inst.Sig[:], inst.Iv)
 		config.ModuleData = bytes.NewBuffer(Encrypt(
 			inst.ModKeyMk[:],
@@ -399,7 +435,9 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 	if config.Entropy != DONUT_ENTROPY_DEFAULT {
 		return b, nil
 	}
-	log.Println("encrypting instance")
+	if config.Verbose {
+		log.Println("encrypting instance")
+	}
 	instData := b.Bytes()
 	offset := 4 + // Len uint32
 		CipherKeyLen + CipherBlockLen + // Instance Crypt
@@ -420,7 +458,9 @@ func CreateInstance(config *DonutConfig) (*bytes.Buffer, error) {
 	if _, err := bc.Write(encInstData); err != nil {         // encrypted body
 		log.Fatal(err)
 	}
-	log.Println("Leaving.")
+	if config.Verbose {
+		log.Println("Leaving.")
+	}
 	return bc, nil
 }
 

--- a/donut/types.go
+++ b/donut/types.go
@@ -106,6 +106,8 @@ type DonutConfig struct {
 
 	inst    *DonutInstance
 	instLen uint32
+
+	Verbose bool // Enable/Disable verbose output
 }
 
 type DonutModule struct {

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		Help: ".NET Mode, set true for .NET exe and DLL files (autodetect not implemented)"})
 	srcFile := parser.String("i", "in", &argparse.Options{Required: true,
 		Help: ".NET assembly, EXE, DLL, VBS, JS or XSL file to execute in-memory."})
+	verbose := parser.Flag("v", "verbose", &argparse.Options{Required: false, Help: "Show verbose output."})
 
 	if err := parser.Parse(os.Args); err != nil || *srcFile == "" {
 		log.Println(parser.Usage(err))
@@ -111,6 +112,7 @@ func main() {
 	config.ModuleName = *moduleName
 	config.Compress = uint32(*zFlag)
 	config.Format = uint32(*format)
+	config.Verbose = *verbose
 
 	if *tFlag {
 		config.Thread = 1


### PR DESCRIPTION
I'm looking to use go-donut as a module in Merlin but I don't want all the verbose output when I use it. I added a Verbose option to the DonutConfig structure and the command line arguments. This will allow silent use of the go-donut package while providing a way to enable verbose output if required.