### PR TITLE
Fix .NET Parameter Buffer

### DIFF
--- a/donut/donut.go
+++ b/donut/donut.go
@@ -199,6 +199,8 @@ func CreateModule(config *DonutConfig, inputFile *bytes.Buffer) error {
 				copy(mod.Param[:], []byte("AAAAAAAA ")[:])
 				copy(mod.Param[9:], []byte(config.Parameters)[:])
 			}
+		} else {
+			copy(mod.Param[:], []byte(config.Parameters)[:])
 		}
 	}
 


### PR DESCRIPTION
Accidentally removed condition in https://github.com/Binject/go-donut/pull/4 that setup arguments for anything that is NOT a `DONUT_MODULE_EXE`. This bug makes it so arguments passed with the `-p` are not used for .NET applications. This patch fixes the problem so that `-p` are passed through.